### PR TITLE
feat: add `progressGradient` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ In this table, you can find all attributes provided by this package:
 | border              | ```null```                        | Set the bar border style by **BoxBorder** |
 | backgroundColor     | const Color(0x00FFFFFF)           | Set the bar background color |
 | progressColor       | const Color(0xFFFA7268)           | Set the bar progressing color |
+| progressGradient       | ```null``` | Set the bar progressing gradient. Overrides `progressColor` |
 | changeColorValue    | ```null```                        | Set a value that progress color should be changed to <br> [0---blue----[**70**]-red-100] |
 | changeProgressColor | const Color(0xFF5F4B8B)           | Color that progressing color will be changed to, whenever **currentValue** greater than **changeColorValue** |
 | displayText         | ```null```                        | Text to display belonging with currentValue. <br>Examples:<br> ```%``` -> ```20%```<br> ```°F``` -> ```80°F```|
@@ -101,6 +102,7 @@ class FAProgressBar {
   final BoxBorder border;
   final Color backgroundColor;
   final Color progressColor;
+  final Gradient progressGradient;
   final int changeColorValue;
   final Color changeProgressColor;
   final String displayText;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,13 +42,24 @@ class _TestAppState extends State<TestApp> {
           child: Column(
         children: <Widget>[
           Container(
-              height: 100,
+              height: 150,
               child: Padding(
                   padding: EdgeInsets.fromLTRB(20, 20, 20, 20),
                   child: Column(children: [
                     FAProgressBar(
                       currentValue: _currentValue,
                       displayText: '%',
+                    ),
+                    Spacer(),
+                    FAProgressBar(
+                      currentValue: _currentValue,
+                      displayText: '%',
+                      progressGradient: LinearGradient(
+                        colors: [
+                          Colors.blue.withOpacity(0.75),
+                          Colors.green.withOpacity(0.75),
+                        ],
+                      ),
                     ),
                     Spacer(),
                     FAProgressBar(

--- a/lib/flutter_animation_progress_bar.dart
+++ b/lib/flutter_animation_progress_bar.dart
@@ -29,6 +29,7 @@ class FAProgressBar extends StatefulWidget {
     this.displayText,
     this.displayTextStyle =
         const TextStyle(color: const Color(0xFFFFFFFF), fontSize: 12),
+    this.progressGradient
   })  : _borderRadius = borderRadius ?? BorderRadius.circular(8),
         super(key: key);
   final double currentValue;
@@ -47,6 +48,7 @@ class FAProgressBar extends StatefulWidget {
   final int? formatValueFixed;
   final String? displayText;
   final TextStyle displayTextStyle;
+  final Gradient? progressGradient;
 
   @override
   _FAProgressBarState createState() => _FAProgressBarState();
@@ -141,7 +143,8 @@ class AnimatedProgressBar extends AnimatedWidget {
     List<Widget> progressWidgets = [];
     Widget progressWidget = Container(
       decoration: BoxDecoration(
-        color: progressColor,
+        color: widget.progressGradient != null ? null : progressColor,
+        gradient: widget.progressGradient,
         borderRadius: widget._borderRadius,
         border: widget.border,
       ),


### PR DESCRIPTION
This change introduces a new option called `progressGradient`. It allows the user to use a gradient instead of a regular color.

```dart
FAProgressBar(
  currentValue: _currentValue,
  displayText: '%',
  progressGradient: LinearGradient(
    colors: [
      Colors.blue.withOpacity(0.75),
      Colors.green.withOpacity(0.75),
    ],
  ),
),
```
Will render this progress bar:
<img width="347" alt="grafik" src="https://user-images.githubusercontent.com/9327096/195317438-89c2c5a4-35c9-47d4-9ae1-63a329cdd878.png">
